### PR TITLE
Add JetBrains Jewel dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ plugins {
     alias(libs.plugins.kover) // Gradle Kover Plugin
     alias(libs.plugins.serialization)
     alias(libs.plugins.gradleIntelliJPlugin)
+    alias(libs.plugins.compose)
 
     id("org.jetbrains.grammarkit") version "2022.3.2.2"
 
@@ -293,6 +294,10 @@ project(":") {
         implementation(project(":exts:ext-endpoints"))
         implementation(project(":exts:ext-container"))
         implementation(project(":exts:devins-lang"))
+
+        // JetBrains Jewel UI library
+        implementation(libs.jewel.core)
+        implementation(libs.jewel.compose)
 
         kover(project(":core"))
         kover(project(":goland"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,9 +6,16 @@ gradleIntelliJPlugin = "2.1.0"
 qodana = "0.1.13"
 kover = "0.7.5"
 
+compose = "1.5.10" # TODO: update to required Compose version
+jewel = "0.13.0"   # TODO: update to required Jewel version
+
 chapi = "2.1.2"
 
 [libraries]
+
+# JetBrains Jewel UI library
+jewel-core = { module = "org.jetbrains.jewel:jewel-core", version.ref = "jewel" }
+jewel-compose = { module = "org.jetbrains.jewel:jewel-compose", version.ref = "jewel" }
 
 
 [plugins]
@@ -19,5 +26,6 @@ kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 qodana = { id = "org.jetbrains.qodana", version.ref = "qodana" }
 serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+compose = { id = "org.jetbrains.compose", version.ref = "compose" }
 
 [bundles]

--- a/src/main/kotlin/cc/unitmesh/devti/JewelExample.kt
+++ b/src/main/kotlin/cc/unitmesh/devti/JewelExample.kt
@@ -1,0 +1,15 @@
+package cc.unitmesh.devti
+
+import androidx.compose.runtime.Composable
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.ui.component.Button
+import org.jetbrains.jewel.ui.component.Text
+
+@Composable
+fun JewelExample() {
+    JewelTheme {
+        Button(onClick = {}) {
+            Text("Hello Jewel")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- set Compose and Jewel versions in version catalog
- apply Compose plugin and add Jewel libraries
- add a minimal Compose sample using Jewel

## Testing
- `./gradlew test -q` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_b_683d0b992ab4832cb90223f47d5a0a9a